### PR TITLE
Add Firebase Crashlytics support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,107 @@
 
 This repository hosts tools for use with building Android apps with Bazel.
 
+```python
+TOOLS_ANDROID_VERSION = "0.1" # or the latest version
+
+http_archive(
+    name = "tools_android",
+    strip_prefix = "tools_android-" + TOOLS_ANDROID_VERSION,
+    url = "https://github.com/bazelbuild/tools_android/archive/%s.tar.gz" % TOOLS_ANDROID_VERSION,
+)
+
+load("@tools_android//tools/googleservices:defs.bzl", "google_services_workspace_dependencies")
+
+google_services_workspace_dependencies()
+```
+
 ## Google Services XML
+
 For an example of integrating with Firebase Cloud Messaging (FCM), [see this example](https://github.com/bazelbuild/examples/tree/master/android/firebase-cloud-messaging).
+
+## Firebase Crashlytics support
+
+In order to integrate Crashlytics into your app, Bazel needs to generate
+configuration files containing information about your Crashlytics setup to
+include in the final APK.
+
+Ensure that you have a Firebase app with Firebase Crashlytics enabled. For more
+information, read the [Before you
+begin](https://firebase.google.com/docs/crashlytics/get-started#android) section
+on the Firebase Crashlytics documentation.
+
+Also ensure that the `google-services.json` file is in your project workspace.
+
+To fetch Crashlytics dependencies, use a Maven resolver tool. For the following
+examples, we will use [rules_maven](https://github.com/jin/rules_maven):
+
+In the WORKSPACE, add the Crashlytics and Google Maven repositories, as well as the dependencies:
+
+```python
+maven_install(
+    artifacts = [
+        "com.crashlytics.sdk.android:crashlytics:2.9.8",
+        "io.fabric.sdk.android:fabric:1.4.7",
+    ],
+    repositories = [
+        "https://maven.fabric.io/public",
+        "https://bintray.com/bintray/jcenter",
+        "https://maven.google.com",
+        "https://repo1.maven.org/maven2",
+    ],
+)
+```
+
+In your BUILD file, create an `android_library` that exports the two artifacts,
+and also create a `crashlytics_android_library`:
+
+```python
+load("@rules_maven//:defs.bzl", "artifact")
+load("@tools_android//tools/crashlytics:defs.bzl", "crashlytics_android_library")
+
+android_library(
+    name = "crashlytics_deps",
+    exports = [
+        artifact("com.crashlytics.sdk.android:crashlytics"),
+        artifact("io.fabric.sdk.android:fabric"),
+    ],
+)
+
+crashlytics_android_library(
+    name = "crashlytics_lib",
+    package_name = "com.example.package",
+    build_id = "9dfea8fe-4d75-48a7-ba28-4ddb7fe74780",
+    google_services_json = "google-services.json",
+)
+```
+
+To generate the Build ID, we have created a tool called `generate_uuid`. Run it with Bazel:
+
+```
+$ bazel run @tools_android//tools/crashlytics:generate_uuid
+
+...
+
+76196b85-5620-4435-81e1-1c0515e0e271
+```
+
+Finally, depend on the `crashlytics_deps` and `crashlytics_lib` libraries in
+your `android_library` target:
+
+```python
+android_library(
+    name = "my_release_lib",
+    srcs = glob(["src/main/**/*.java"]),
+    manifest = "AndroidManifest.xml",
+    resource_files = glob(["res/**/*"]),
+    deps = [
+        ":crashlytics_lib",
+        ":crashlytics_deps", 
+    ],
+)
+```
+
+To force a crash and find out if Crashlytics is working properly, [follow the
+steps in Crashlytics
+documentation](https://firebase.google.com/docs/crashlytics/force-a-crash).
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This repository hosts tools for use with building Android apps with Bazel.
 
+## Setup
+
+To use this with Bazel, add the following snippet to your WORKSPACE file:
+
 ```python
 TOOLS_ANDROID_VERSION = "0.1" # or the latest version
 
@@ -18,91 +22,10 @@ google_services_workspace_dependencies()
 
 ## Google Services XML
 
-For an example of integrating with Firebase Cloud Messaging (FCM), [see this example](https://github.com/bazelbuild/examples/tree/master/android/firebase-cloud-messaging).
+For an example of integrating with Firebase Cloud Messaging (FCM), [see this
+example](https://github.com/bazelbuild/examples/tree/master/android/firebase-cloud-messaging).
 
 ## Firebase Crashlytics support
 
-In order to integrate Crashlytics into your app, Bazel needs to generate
-configuration files containing information about your Crashlytics setup to
-include in the final APK.
-
-Ensure that you have a Firebase app with Firebase Crashlytics enabled. For more
-information, read the [Before you
-begin](https://firebase.google.com/docs/crashlytics/get-started#android) section
-on the Firebase Crashlytics documentation.
-
-Also ensure that the `google-services.json` file is in your project workspace.
-
-To fetch Crashlytics dependencies, use a Maven resolver tool. For the following
-examples, we will use [rules_maven](https://github.com/jin/rules_maven):
-
-In the WORKSPACE, add the Crashlytics and Google Maven repositories, as well as the dependencies:
-
-```python
-maven_install(
-    artifacts = [
-        "com.crashlytics.sdk.android:crashlytics:2.9.8",
-        "io.fabric.sdk.android:fabric:1.4.7",
-    ],
-    repositories = [
-        "https://maven.fabric.io/public",
-        "https://bintray.com/bintray/jcenter",
-        "https://maven.google.com",
-        "https://repo1.maven.org/maven2",
-    ],
-)
-```
-
-In your BUILD file, create an `android_library` that exports the two artifacts,
-and also create a `crashlytics_android_library`:
-
-```python
-load("@rules_maven//:defs.bzl", "artifact")
-load("@tools_android//tools/crashlytics:defs.bzl", "crashlytics_android_library")
-
-android_library(
-    name = "crashlytics_deps",
-    exports = [
-        artifact("com.crashlytics.sdk.android:crashlytics"),
-        artifact("io.fabric.sdk.android:fabric"),
-    ],
-)
-
-crashlytics_android_library(
-    name = "crashlytics_lib",
-    package_name = "com.example.package",
-    build_id = "9dfea8fe-4d75-48a7-ba28-4ddb7fe74780",
-    google_services_json = "google-services.json",
-)
-```
-
-To generate the Build ID, we have created a tool called `generate_uuid`. Run it with Bazel:
-
-```
-$ bazel run @tools_android//tools/crashlytics:generate_uuid
-
-...
-
-76196b85-5620-4435-81e1-1c0515e0e271
-```
-
-Finally, depend on the `crashlytics_deps` and `crashlytics_lib` libraries in
-your `android_library` target:
-
-```python
-android_library(
-    name = "my_release_lib",
-    srcs = glob(["src/main/**/*.java"]),
-    manifest = "AndroidManifest.xml",
-    resource_files = glob(["res/**/*"]),
-    deps = [
-        ":crashlytics_lib",
-        ":crashlytics_deps", 
-    ],
-)
-```
-
-To force a crash and find out if Crashlytics is working properly, [follow the
-steps in Crashlytics
-documentation](https://firebase.google.com/docs/crashlytics/force-a-crash).
-
+To integrate Crashlytics into your Android app, follow the [instructions in the
+README](tools/crashlytics/README.md) in the `crashlytics` directory.

--- a/tools/crashlytics/BUILD
+++ b/tools/crashlytics/BUILD
@@ -1,0 +1,15 @@
+exports_files(["defs.bzl"])
+
+java_binary(
+    name = "crashlytics",
+    srcs = ["com/bazel/crashlytics/Crashlytics.java"],
+    main_class = "com.bazel.crashlytics.Crashlytics",
+    visibility = ["//visibility:public"],
+)
+
+java_binary(
+    name = "generate_uuid",
+    srcs = ["com/bazel/crashlytics/GenerateRandomUUID.java"],
+    main_class = "com.bazel.crashlytics.GenerateRandomUUID",
+    visibility = ["//visibility:public"],
+)

--- a/tools/crashlytics/README.md
+++ b/tools/crashlytics/README.md
@@ -1,0 +1,87 @@
+# Firebase Crashlytics support with Bazel
+
+In order to integrate Crashlytics into your app, Bazel needs to generate
+configuration files containing information about your Crashlytics setup to
+include in the final APK.
+
+Ensure that you have a Firebase app with Firebase Crashlytics enabled. For more
+information, read the [Before you
+begin](https://firebase.google.com/docs/crashlytics/get-started#android) section
+on the Firebase Crashlytics documentation.
+
+Also ensure that the `google-services.json` file is in your project workspace.
+
+To fetch Crashlytics dependencies, use a Maven resolver tool. For the following
+examples, we will use [rules_maven](https://github.com/jin/rules_maven):
+
+In the WORKSPACE, add the Crashlytics and Google Maven repositories, as well as
+the dependencies:
+
+```python
+maven_install(
+    artifacts = [
+        "com.crashlytics.sdk.android:crashlytics:2.9.8",
+        "io.fabric.sdk.android:fabric:1.4.7",
+    ],
+    repositories = [
+        "https://maven.fabric.io/public",
+        "https://bintray.com/bintray/jcenter",
+        "https://maven.google.com",
+        "https://repo1.maven.org/maven2",
+    ],
+)
+```
+
+In your BUILD file, create a `crashlytics_android_library`. For convenience, you
+can also create an `android_library` that exports the two artifacts dependencies.
+
+```python
+load("@rules_maven//:defs.bzl", "artifact")
+load("@tools_android//tools/crashlytics:defs.bzl", "crashlytics_android_library")
+
+android_library(
+    name = "crashlytics_deps",
+    exports = [
+        artifact("com.crashlytics.sdk.android:crashlytics"),
+        artifact("io.fabric.sdk.android:fabric"),
+    ],
+)
+
+crashlytics_android_library(
+    name = "crashlytics_lib",
+    package_name = "com.example.package",
+    build_id = "9dfea8fe-4d75-48a7-ba28-4ddb7fe74780",
+    google_services_json = "google-services.json",
+)
+```
+
+To generate the Build ID, we have created a tool called `generate_uuid`. Run it
+with Bazel:
+
+```
+$ bazel run @tools_android//tools/crashlytics:generate_uuid
+
+...
+
+76196b85-5620-4435-81e1-1c0515e0e271
+```
+
+Finally, depend on the `crashlytics_deps` and `crashlytics_lib` libraries in
+your `android_library` target:
+
+```python
+android_library(
+    name = "my_release_lib",
+    srcs = glob(["src/main/**/*.java"]),
+    manifest = "AndroidManifest.xml",
+    resource_files = glob(["res/**/*"]),
+    deps = [
+        ":crashlytics_lib",
+        ":crashlytics_deps", 
+    ],
+)
+```
+
+To force a crash and find out if Crashlytics is working properly, [follow the
+steps in Crashlytics
+documentation](https://firebase.google.com/docs/crashlytics/force-a-crash).

--- a/tools/crashlytics/README.md
+++ b/tools/crashlytics/README.md
@@ -32,12 +32,26 @@ maven_install(
 )
 ```
 
-In your BUILD file, create a `crashlytics_android_library`. For convenience, you
-can also create an `android_library` that exports the two artifacts dependencies.
+In your BUILD file, declare `crashlytics_android_library` and
+`google_services_xml`. For convenience, you can also create an `android_library`
+that exports the two artifacts dependencies.
 
 ```python
 load("@rules_maven//:defs.bzl", "artifact")
 load("@tools_android//tools/crashlytics:defs.bzl", "crashlytics_android_library")
+load("@tools_android//tools/googleservices:defs.bzl", "google_services_xml")
+
+GOOGLE_SERVICES_RESOURCES = google_services_xml(
+    package_name = "com.example.package",
+    google_services_json = "google-services.json",
+)
+
+crashlytics_android_library(
+    name = "crashlytics_lib",
+    package_name = "com.example.package",
+    build_id = "9dfea8fe-4d75-48a7-ba28-4ddb7fe74780",
+    resource_files = GOOGLE_SERVICES_RESOURCES,
+)
 
 android_library(
     name = "crashlytics_deps",
@@ -45,13 +59,6 @@ android_library(
         artifact("com.crashlytics.sdk.android:crashlytics"),
         artifact("io.fabric.sdk.android:fabric"),
     ],
-)
-
-crashlytics_android_library(
-    name = "crashlytics_lib",
-    package_name = "com.example.package",
-    build_id = "9dfea8fe-4d75-48a7-ba28-4ddb7fe74780",
-    google_services_json = "google-services.json",
 )
 ```
 
@@ -66,8 +73,7 @@ $ bazel run @tools_android//tools/crashlytics:generate_uuid
 76196b85-5620-4435-81e1-1c0515e0e271
 ```
 
-Finally, depend on the `crashlytics_deps` and `crashlytics_lib` libraries in
-your `android_library` target:
+Finally, depend on the `crashlytics_deps` and `crashlytics_lib` libraries.
 
 ```python
 android_library(

--- a/tools/crashlytics/com/bazel/crashlytics/Crashlytics.java
+++ b/tools/crashlytics/com/bazel/crashlytics/Crashlytics.java
@@ -1,0 +1,21 @@
+package com.bazel.crashlytics;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.io.IOException;
+
+public class Crashlytics {
+
+  public static void main(String[] args) throws Exception {
+    String propertiesFileContent = args[0];
+    String outFile = args[1];
+
+    try (BufferedWriter w = Files.newBufferedWriter(Paths.get(outFile))) {
+      w.write(propertiesFileContent);
+    }
+
+  }
+
+}

--- a/tools/crashlytics/com/bazel/crashlytics/Crashlytics.java
+++ b/tools/crashlytics/com/bazel/crashlytics/Crashlytics.java
@@ -6,6 +6,13 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.io.IOException;
 
+/**
+ * A simple executable to echo content into a file.
+ *
+ * Instead of using `echo` in a genrule, we can use this wrapper to simplify
+ * multiplatform support. Windows and Linux has different syntax for `echo`
+ * calls.
+ */
 public class Crashlytics {
 
   public static void main(String[] args) throws Exception {

--- a/tools/crashlytics/com/bazel/crashlytics/GenerateRandomUUID.java
+++ b/tools/crashlytics/com/bazel/crashlytics/GenerateRandomUUID.java
@@ -1,0 +1,9 @@
+package com.bazel.crashlytics;
+
+public class GenerateRandomUUID {
+
+  public static void main(String[] args) {
+    System.out.println(java.util.UUID.randomUUID().toString());
+  }
+
+}

--- a/tools/crashlytics/defs.bzl
+++ b/tools/crashlytics/defs.bzl
@@ -1,0 +1,69 @@
+load("@tools_android//tools/googleservices:defs.bzl", "google_services_xml")
+
+def crashlytics_android_library(
+    name,
+    package_name,
+    build_id,
+    google_services_json):
+
+  _CRASHLYTICS_PROP_TEMPLATE = \
+  """build_id={build_id}
+package_name={package_name}"""
+  crashlytics_properties_file = "crashlytics-build.properties"
+  crashlytics_properties_file_content = _CRASHLYTICS_PROP_TEMPLATE.format(
+      build_id = build_id,
+      package_name = package_name,
+  )
+
+  native.genrule(
+      name = "%s_crashlytics_setup_properties" % name,
+      outs = [crashlytics_properties_file],
+      tools = ["@tools_android//tools/crashlytics"],
+      cmd = "$(location @tools_android//tools/crashlytics) \"%s\" $@" % crashlytics_properties_file_content,
+  )
+
+  # Generate the unique identifier for Fabric backend to identify builds.
+  # https://docs.fabric.io/android/crashlytics/build-tools.html#optimize-builds-when-you-re-not-proguarding-or-using-beta-by-crashlytics
+  _CRASHLYTICS_RES_TEMPLATE = \
+  """<?xml version=\\"1.0\\" encoding=\\"utf-8\\" standalone=\\"no\\"?>
+<resources xmlns:tools=\\"http://schemas.android.com/tools\\">
+    <string tools:ignore=\\"UnusedResources,TypographyDashes\\" name=\\"com.crashlytics.android.build_id\\" translatable=\\"false\\">{build_id}</string>
+</resources>"""
+  crashlytics_res_values_file = "res/values/com_crashlytics_build_id.xml"
+  crashlytics_res_values_file_content = _CRASHLYTICS_RES_TEMPLATE.format(build_id = build_id)
+
+  native.genrule(
+      name = "%s_crashlytics_setup_res" % name,
+      outs = [crashlytics_res_values_file],
+      tools = ["@tools_android//tools/crashlytics"],
+      cmd = "$(location @tools_android//tools/crashlytics) \"%s\" $@" % crashlytics_res_values_file_content,
+  )
+
+  _CRASHLYTICS_MANIFEST_TEMPLATE = \
+"""<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
+<manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
+          package=\\"{package_name}\\">
+</manifest>
+"""
+  crashlytics_manifest_file = "CrashlyticsManifest.xml"
+  crashlytics_manifest_file_content = _CRASHLYTICS_MANIFEST_TEMPLATE.format(package_name = package_name)
+
+  native.genrule(
+      name = "%s_crashlytics_setup_manifest" % name,
+      outs = [crashlytics_manifest_file],
+      tools = ["@tools_android//tools/crashlytics"],
+      cmd = "$(location @tools_android//tools/crashlytics) \"%s\" $@" % crashlytics_manifest_file_content,
+  )
+
+  google_services_xml_files = google_services_xml(
+      package_name = package_name,
+      google_services_json = google_services_json,
+  )
+
+  native.android_library(
+      name = name,
+      assets = [crashlytics_properties_file],
+      assets_dir = "",
+      manifest = crashlytics_manifest_file,
+      resource_files = google_services_xml_files + [crashlytics_res_values_file],
+  )

--- a/tools/crashlytics/defs.bzl
+++ b/tools/crashlytics/defs.bzl
@@ -1,11 +1,4 @@
-load("@tools_android//tools/googleservices:defs.bzl", "google_services_xml")
-
-def crashlytics_android_library(
-    name,
-    package_name,
-    build_id,
-    google_services_json):
-
+def crashlytics_android_library(name, package_name, build_id, resource_files):
   _CRASHLYTICS_PROP_TEMPLATE = \
   """build_id={build_id}
 package_name={package_name}"""
@@ -55,15 +48,10 @@ package_name={package_name}"""
       cmd = "$(location @tools_android//tools/crashlytics) \"%s\" $@" % crashlytics_manifest_file_content,
   )
 
-  google_services_xml_files = google_services_xml(
-      package_name = package_name,
-      google_services_json = google_services_json,
-  )
-
   native.android_library(
       name = name,
       assets = [crashlytics_properties_file],
       assets_dir = "",
       manifest = crashlytics_manifest_file,
-      resource_files = google_services_xml_files + [crashlytics_res_values_file],
+      resource_files = [crashlytics_res_values_file] + resource_files,
   )


### PR DESCRIPTION
This PR adds support for integrating Crashlytics into Bazel Android builds.

For more information, see https://github.com/bazelbuild/bazel/issues/7159