### PR TITLE
Add custom_package to android_library generated by crashlytics_android_library

### DIFF
--- a/tools/crashlytics/defs.bzl
+++ b/tools/crashlytics/defs.bzl
@@ -52,6 +52,7 @@ package_name={package_name}"""
       name = name,
       assets = [crashlytics_properties_file],
       assets_dir = "",
+      custom_package = package_name,
       manifest = crashlytics_manifest_file,
       resource_files = [crashlytics_res_values_file] + resource_files,
   )


### PR DESCRIPTION
While trying to set up a crashlytics example using [bazel firebase example](https://github.com/bazelbuild/examples/tree/master/android/firebase-cloud-messaging) as a base I discovered that it doesn't build. After following the [README](https://github.com/bazelbuild/tools_android/blob/c44f75b43bec2ec744e6ee373f0da577f5270f52/tools/crashlytics/README.md) and updating the WORKSPACE file to a recent commit of `tools_android`, it turned out that bazel fails with an error
```
ERROR: <path-to-bazel-examples>/android/firebase-cloud-messaging/app/BUILD:9:1: in android_library rule //app:crashlytics_lib: The location of your BUILD file determines the Java package used for Android resource processing. A directory named "java" or "javatests" will be used as your Java source root and the path of your BUILD file relative to the Java source root will be used as the package for Android resource processing. The Java source root could not be determined for "app". Move your BUILD file under a java or javatests directory, or set the 'custom_package' attribute.
ERROR: Analysis of target '//app:app' failed; build aborted: Analysis of target '//app:crashlytics_lib' failed; build aborted
```
It fails because bazel can't determine the package from the location of the BUILD file.
This PR fixes it by explicitly setting `custom_package` on the `android_library` created by `crashlytics_android_library`.