### PR TITLE
Use replace maven_jar with jvm_maven_import_external

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore all bazel-* symlinks. There is no full list since this can change
+# based on the name of the directory bazel is cloned into.
+/bazel-*

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,3 @@
+load("//tools/googleservices:defs.bzl", "google_services_workspace_dependencies")
+
+google_services_workspace_dependencies()

--- a/tools/googleservices/defs.bzl
+++ b/tools/googleservices/defs.bzl
@@ -1,9 +1,16 @@
 """Macros to support Google services, e.g. Firebase Cloud Messaging."""
 
+
+load("@bazel_tools//tools/build_defs/repo:jvm.bzl", "jvm_maven_import_external")
+
+
 def google_services_xml(package_name, google_services_json):
   """Creates Android resource XML for Google services.
 
   The XML is based on a google-services.json file.
+
+  This macro assumes that the android tools repository is named "tools_android"
+  in the top-level project's WORKSPACE file.
 
   Args:
     package_name: The package name (or application ID) of the Android app.
@@ -33,7 +40,10 @@ def google_services_xml(package_name, google_services_json):
 
 
 def google_services_workspace_dependencies():
-  native.maven_jar(
+  jvm_maven_import_external(
     name = "com_google_code_gson_2_8_2",
     artifact = "com.google.code.gson:gson:2.8.2",
+    artifact_sha256 = "b7134929f7cc7c04021ec1cc27ef63ab907e410cf0588e397b8851181eb91092",
+    server_urls = ["https://repo1.maven.org/maven2/"],
+    licenses = ["notice"],
   )

--- a/tools/googleservices/defs.bzl
+++ b/tools/googleservices/defs.bzl
@@ -9,7 +9,7 @@ def google_services_xml(package_name, google_services_json):
 
   The XML is based on a google-services.json file.
 
-  This macro assumes that the android tools repository is named "tools_android"
+  This macro assumes that the Android tools repository is named "tools_android"
   in the top-level project's WORKSPACE file.
 
   Args:


### PR DESCRIPTION
Update google_services_workspace_dependencies() to use jvm_maven_import_external() instead of the now-removed native.maven_jar().