### PR TITLE
Specify more exact `assets_dir`

### DIFF
--- a/tools/crashlytics/defs.bzl
+++ b/tools/crashlytics/defs.bzl
@@ -2,7 +2,7 @@ def crashlytics_android_library(name, package_name, build_id, resource_files):
   _CRASHLYTICS_PROP_TEMPLATE = \
   """build_id={build_id}
 package_name={package_name}"""
-  crashlytics_properties_file = "_%s_crashlytics/crashlytics-build.properties" % name
+  crashlytics_properties_file = "_%s_crashlytics/assets/crashlytics-build.properties" % name
   crashlytics_properties_file_content = _CRASHLYTICS_PROP_TEMPLATE.format(
       build_id = build_id,
       package_name = package_name,
@@ -51,7 +51,7 @@ package_name={package_name}"""
   native.android_library(
       name = name,
       assets = [crashlytics_properties_file],
-      assets_dir = "",
+      assets_dir = "_%s_crashlytics/assets" % name,
       custom_package = package_name,
       manifest = crashlytics_manifest_file,
       resource_files = [crashlytics_res_values_file] + resource_files,


### PR DESCRIPTION
We saw an issue related to https://github.com/bazelbuild/rules_android/issues/310: files besides `crashlytics-build.properties` end up affecting and being pulled into outputs of resource processing actions (e.g. `assets.bin`). We occasionally saw failures like:

```
ERROR: <foo>/app/debug/crashlytics/BUILD.bazel:11:28: Merging Android assets for //<foo>/app/debug/crashlytics:crashlytics failed: Worker process did not return a WorkResponse:

---8<---8<--- Start of log, file at /private/var/tmp/_bazel_spotify-buildagent/985b781559c7830232d18af8d0be54d9/bazel-workers/worker-12-AndroidAssetMerger.log ---8<---8<---
(empty)
---8<---8<--- End of log ---8<---8<---
```

which went away if we changed the `build_id`.

This change generates an `assets` subfolder with the properties file and specifies that as `assets_dir`. This way only that single file ends up as an input to the resource processing actions.