### PR TITLE
Use recognizeable string `id`

### DIFF
--- a/tools/crashlytics/defs.bzl
+++ b/tools/crashlytics/defs.bzl
@@ -20,7 +20,7 @@ package_name={package_name}"""
   _CRASHLYTICS_RES_TEMPLATE = \
   """<?xml version=\\"1.0\\" encoding=\\"utf-8\\" standalone=\\"no\\"?>
 <resources xmlns:tools=\\"http://schemas.android.com/tools\\">
-    <string tools:ignore=\\"UnusedResources,TypographyDashes\\" name=\\"com.crashlytics.android.build_id\\" translatable=\\"false\\">{build_id}</string>
+    <string tools:ignore=\\"UnusedResources,TypographyDashes\\" name=\\"com.google.firebase.crashlytics.mapping_file_id\\" translatable=\\"false\\">{build_id}</string>
 </resources>"""
   crashlytics_res_values_file = "_%s_crashlytics/res/values/com_crashlytics_build_id.xml" % name
   crashlytics_res_values_file_content = _CRASHLYTICS_RES_TEMPLATE.format(build_id = build_id)


### PR DESCRIPTION
When trying to upload the proguard mapping file with Firebase CLI, we get an error:

```
[CRASHLYTICS LOG DEBUG] Extracting mappingFileId from resource file: ~/src/project/android_res.xml
java.lang.IllegalArgumentException: Resource file does not contain a valid mapping file id: ~/src/project/android_res.xml
```

According to the documentation we need to:
1. Generate unique mapping file ID in the xml file (the one generated by genrule inside `crashlytics_android_library`)
2. Upload the proguard mapping file and associate it with the mapping file ID.

CLI docs: https://firebase.google.com/docs/cli#crashlytics-commands