### PR TITLE
Remove hyphens from UUID to satisfy mapping file ID requirements

### DIFF
--- a/tools/crashlytics/README.md
+++ b/tools/crashlytics/README.md
@@ -49,7 +49,7 @@ GOOGLE_SERVICES_RESOURCES = google_services_xml(
 crashlytics_android_library(
     name = "crashlytics_lib",
     package_name = "com.example.package",
-    build_id = "9dfea8fe-4d75-48a7-ba28-4ddb7fe74780",
+    build_id = "9dfea8fe4d7548a7ba284ddb7fe74780",
     resource_files = GOOGLE_SERVICES_RESOURCES,
 )
 
@@ -62,15 +62,15 @@ android_library(
 )
 ```
 
-To generate the Build ID, we have created a tool called `generate_uuid`. Run it
-with Bazel:
+To generate the Build ID (which is a UUID without hyphens),
+we have created a tool called `generate_uuid`. Run it with Bazel:
 
 ```
 $ bazel run @tools_android//tools/crashlytics:generate_uuid
 
 ...
 
-76196b85-5620-4435-81e1-1c0515e0e271
+76196b855620443581e11c0515e0e271
 ```
 
 Finally, depend on the `crashlytics_deps` and `crashlytics_lib` libraries.

--- a/tools/crashlytics/com/bazel/crashlytics/GenerateRandomUUID.java
+++ b/tools/crashlytics/com/bazel/crashlytics/GenerateRandomUUID.java
@@ -3,7 +3,7 @@ package com.bazel.crashlytics;
 public class GenerateRandomUUID {
 
   public static void main(String[] args) {
-    System.out.println(java.util.UUID.randomUUID().toString());
+    System.out.println(java.util.UUID.randomUUID().toString().replace("-", ""));
   }
 
 }


### PR DESCRIPTION
I don't know if this is official or documented anywhere, but it looks like the mapping file ID must be a UUID *without hyphens*. Uploading a file with a UUID like 6ac7912c-d163-47a0-ae4e-f6d3ad3a21c7 results in an API response like:

```
"error": {
    "code": 3,
    "message": "Invalid URL: Not a valid uuid."
}
```

Removing the hyphens makes it work.

I'm not sure how "generalizable" we want the code in this repository to be. It seems to me that this target should specifically be used to generate a UUID that can be used directly for a mapping file upload. To that end, I think it is correct to follow the exact format that makes this work, rather than make something purely generalizable.