### PR TITLE
Add Crashlytics suffix to keep filename to avoid clashes

### DIFF
--- a/tools/crashlytics/defs.bzl
+++ b/tools/crashlytics/defs.bzl
@@ -38,7 +38,7 @@ package_name={package_name}"""
   """<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
 <resources xmlns:tools=\\"http://schemas.android.com/tools\\"
     tools:keep=\\"@string/com_google_firebase_crashlytics_mapping_file_id\\" />"""
-  crashlytics_res_keep_file = "_%s_crashlytics/res/raw/%s.keep.xml" % (name, package_name)
+  crashlytics_res_keep_file = "_%s_crashlytics/res/raw/%s-crashlytics.keep.xml" % (name, package_name)
 
   native.genrule(
       name = "%s_crashlytics_setup_res_keep" % name,


### PR DESCRIPTION
It's not uncommon to have a keep file in consuming apps. In my own case, this resulted in:

```
CONFLICT: raw/com.ergatta.bolt.keep is provided with ambiguous priority from:
	src/main/kotlin/com/ergatta/bolt/res/raw/com.ergatta.bolt.keep.xml
	bazel-out/darwin_arm64-opt-android-ST-4cf3fc44044d/bin/src/main/kotlin/com/ergatta/bolt/_crashlytics_crashlytics/res/raw/com.ergatta.bolt.keep.xml
```

This makes it unique.